### PR TITLE
Exclude line break from token string after reading from file

### DIFF
--- a/ghtop.py
+++ b/ghtop.py
@@ -19,7 +19,7 @@ url = "https://api.github.com/events"
 def get_token():
     try:
         f = open("ghtoken.txt", "r")
-        token = f.read()
+        token = f.read().rstrip()
         return token
     except:
         print("Create a GitHub PAT and put it in ghtoken.txt: https://github.com/settings/tokens", file=sys.stderr)


### PR DESCRIPTION
Fixes ValueError if the token file was created with a line break after the token (default behavior in most systems):
```
ValueError: Invalid header value b'token XXX\n'
```