### PR TITLE
Use standard path for python interpreter

### DIFF
--- a/ghtop.py
+++ b/ghtop.py
@@ -1,4 +1,4 @@
-#!/usr/local/bin/python3
+#!/usr/bin/env python3
 
 import time, datetime, pytz
 import json


### PR DESCRIPTION
This may be a more sanitized way of invoking the interpreter.